### PR TITLE
mark to_wkb docstring as raw string

### DIFF
--- a/python/arctern/geoseries/geoseries.py
+++ b/python/arctern/geoseries/geoseries.py
@@ -1201,6 +1201,17 @@ class GeoSeries(Series):
 
         :rtype: arctern.GeoSeries
         :return: A arctern.GeoSeries constructed from geopandas.GeoSeries.
+
+        :example:
+        >>> import geopandas as gpd
+        >>> from shapely.geometry import Point, Polygon
+        >>> from arctern import GeoSeries
+        >>> gpd_s = gpd.GeoSeries([Point(1,1), Polygon(((1,1), (1,2), (2,3), (1,1)))])
+        >>> arctern_s = GeoSeries.from_geopandas(gpd_s)
+        >>> arctern_s
+        0                    POINT (1 1)
+        1    POLYGON ((1 1,1 2,2 3,1 1))
+        dtype: GeoDtype
         """
         import geopandas as gpd
         import shapely.wkb

--- a/python/arctern/geoseries/geoseries.py
+++ b/python/arctern/geoseries/geoseries.py
@@ -1042,7 +1042,7 @@ class GeoSeries(Series):
         return _property_op(arctern.ST_AsText, self)
 
     def to_wkb(self):
-        """
+        r"""
         Transform each geometry to WKB formed bytes object.
 
         :rtype: Series(dtype: object)


### PR DESCRIPTION
Currently, to_wkb example can not be showed  correctly in doc website.
https://arctern.io/docs/versions/v0.2.x/development-doc-cn/html/api_reference/standalone_api/api/arctern.GeoSeries.to_wkb.html#arctern.GeoSeries.to_wkb

Mark it as raw string will solve it.