### PR TITLE
[skip ci] make to_wkb doctring as raw string

### DIFF
--- a/python/arctern/geoseries/geoseries.py
+++ b/python/arctern/geoseries/geoseries.py
@@ -1042,7 +1042,7 @@ class GeoSeries(Series):
         return _property_op(arctern.ST_AsText, self)
 
     def to_wkb(self):
-        """
+        r"""
         Transform each geometry to WKB formed bytes object.
 
         :rtype: Series(dtype: object)


### PR DESCRIPTION
Currently, to_wkb example can not be showed correctly(bytes is not shown correctly) in doc website.
https://arctern.io/docs/versions/v0.2.x/development-doc-cn/html/api_reference/standalone_api/api/arctern.GeoSeries.to_wkb.html#arctern.GeoSeries.to_wkb

Mark it as raw string will solve it.